### PR TITLE
Bump mail dependency

### DIFF
--- a/fyi.gemspec
+++ b/fyi.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths      = %w[ lib ]
 
   s.add_development_dependency 'rake', '0.9.2.2'
-  s.add_dependency 'mail',    '~> 2.4.4'
+  s.add_dependency 'mail',    '~> 2.5.3'
   s.add_dependency 'systemu', '>= 2.4.0'
 end


### PR DESCRIPTION
This resolves a conflict with the latest Rails security release that
bumped the mail gem dependency to 2.5.3

See
https://github.com/rails/rails/commit/dac811e8542ee7b9abb88a5839fa22dd59c7c737

Without a test suite I am unable to verify if there are breaking changes with this gem.
